### PR TITLE
fix / usage section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ module "vault_secretsync" {
 }
 ```
 
-Remove vault secret sync destination (all secret associations must be removed before this can be done):
+Remove vault secret sync destination by adding `delete_sync_destination = true` (NOTE: all secret associations must be removed before this can be done):
 ```terraform
 module "vault_secretsync" {
   source  = "SPHTech-Platform/vault-enterprise-secret-sync"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create and manage [Vault Enterprise Secret Sync](https://developer.hashicorp.com
 - All the vault secret associations must be removed before the secret sync destination can be removed. Vault will return this error message if secret associations still exist: `store cannot be deleted because it is still managing secrets`.
 
 ## Usage
-Create Vault Secret Sync destination and association:
+Create Vault Secret Sync destination and secret association:
 ```terraform
 module "vault_secretsync" {
   source  = "SPHTech-Platform/vault-enterprise-secret-sync"
@@ -35,17 +35,15 @@ module "vault_secretsync" {
 
   name = "vault-ss"
 
+  # Removing secret in this section does not remove the secret association
   associate_secrets = {
     foo = {
       mount       = "mount_foo"
       secret_name = "foo_secret"
     }
-    hello = {
-      mount       = "mount_hello"
-      secret_name = "hello_secret"
-    }
   }
 
+  # Add the secret information here to remove the secret association
   unassociate_secrets = {
     hello = {
       mount       = "mount_hello"
@@ -75,11 +73,10 @@ module "vault_secretsync" {
   }
 
   delete_all_secret_associations = true
-  delete_sync_destination	     = true
 }
 ```
 
-Remove vault secret sync destination:
+Remove vault secret sync destination (all secret associations must be removed before this can be done):
 ```terraform
 module "vault_secretsync" {
   source  = "SPHTech-Platform/vault-enterprise-secret-sync"
@@ -99,6 +96,7 @@ module "vault_secretsync" {
   }
 
   delete_all_secret_associations = true
+  delete_sync_destination        = true
 ```
 
 <!-- BEGIN_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ module "vault_secretsync" {
   unassociate_secrets = {
     hello = {
       mount       = "mount_hello"
-      secret_name = ["hello_secret"]
+      secret_name = [
+        "hello_secret_1",
+        "hello_secret_2",
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ module "vault_secretsync" {
     }
     hello = {
       mount       = "mount_hello"
-      secret_name = ["hello_secret"]
+      secret_name = [
+        "hello_secret_1",
+        "hello_secret_2",
+      ]
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ module "vault_secretsync" {
     }
     hello = {
       mount       = "mount_hello"
-      secret_name = ["hello_secret"]
+      secret_name = [
+        "hello_secret_1",
+        "hello_secret_2",
+      ]
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ module "vault_secretsync" {
   associate_secrets = {
     foo = {
       mount       = "mount_foo"
-      secret_name = "foo_secret"
+      secret_name = ["foo_secret"]
     }
     hello = {
       mount       = "mount_hello"
-      secret_name = "hello_secret"
+      secret_name = ["hello_secret"]
     }
   }
 }
@@ -39,7 +39,7 @@ module "vault_secretsync" {
   associate_secrets = {
     foo = {
       mount       = "mount_foo"
-      secret_name = "foo_secret"
+      secret_name = ["foo_secret"]
     }
   }
 
@@ -47,7 +47,7 @@ module "vault_secretsync" {
   unassociate_secrets = {
     hello = {
       mount       = "mount_hello"
-      secret_name = "hello_secret"
+      secret_name = ["hello_secret"]
     }
   }
 }
@@ -64,11 +64,11 @@ module "vault_secretsync" {
   associate_secrets = {
     foo = {
       mount       = "mount_foo"
-      secret_name = "foo_secret"
+      secret_name = ["foo_secret"]
     }
     hello = {
       mount       = "mount_hello"
-      secret_name = "hello_secret"
+      secret_name = ["hello_secret"]
     }
   }
 
@@ -87,11 +87,11 @@ module "vault_secretsync" {
   associate_secrets = {
     foo = {
       mount       = "mount_foo"
-      secret_name = "foo_secret"
+      secret_name = ["foo_secret"]
     }
     hello = {
       mount       = "mount_hello"
-      secret_name = "hello_secret"
+      secret_name = ["hello_secret"]
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "vault_secretsync" {
 }
 ```
 
-Remove some vault secrets from association:
+Remove some vault secrets from association by adding the attribute `unassociate_secrets`:
 ```terraform
 module "vault_secretsync" {
   source  = "SPHTech-Platform/vault-enterprise-secret-sync"
@@ -59,7 +59,7 @@ module "vault_secretsync" {
 }
 ```
 
-Remove all vault secrets from association:
+Remove all vault secrets from association by adding the attribute `delete_all_secret_associations = true`:
 ```terraform
 module "vault_secretsync" {
   source  = "SPHTech-Platform/vault-enterprise-secret-sync"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module "vault_secretsync" {
 }
 ```
 
-Remove vault secret sync destination by adding `delete_sync_destination = true` (NOTE: all secret associations must be removed before this can be done):
+Remove vault secret sync destination by adding `delete_sync_destination = true` (NOTE: all secret associations must be removed before this can be done i.e. `delete_all_secret_associations = true`):
 ```terraform
 module "vault_secretsync" {
   source  = "SPHTech-Platform/vault-enterprise-secret-sync"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ module "vault_secretsync" {
     }
     hello = {
       mount       = "mount_hello"
-      secret_name = ["hello_secret"]
+      secret_name = [
+        "hello_secret_1",
+        "hello_secret_2",
+      ]
     }
   }
 }


### PR DESCRIPTION
1. Fix a error in the usage section of the README documentation.
2. Added a comment to ensure that user is aware that secret associations needs to be removed before sync destination can be remove.