### PR TITLE
chore: shorten key rotation to 30 days and tf validation checks

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -32,9 +32,8 @@ resource "aws_iam_access_key" "vault_secretsync" {
   }
 }
 
-# Trigger access key rotation every 90 days
 resource "time_rotating" "iam_user_secretsync_access_key" {
-  rotation_days = 90
+  rotation_days = local.iam_key_rotation_days
 }
 
 resource "null_resource" "rotate_access_key" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  # checks for keys older than 60 days
-  age_in_days             = timeadd(plantimestamp(), "-1440h") # 60 days (60*24 hours)
+  # checks for keys older than 30 days
+  age_in_days             = timeadd(plantimestamp(), "-1080h") # 45 days (45*24 hours)
   iam_key_rotation_days   = 30                                 # rotate key if older than 30 days
   sync_base_path          = "sys/sync/destinations"
   destination_name        = "${var.name}-${var.region}-${random_id.this.hex}"

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,7 @@
 locals {
-  age_in_days             = timeadd(plantimestamp(), "-2160h") # 90 days (90*24 hours)
+  # checks for keys older than 60 days
+  age_in_days             = timeadd(plantimestamp(), "-1440h") # 60 days (60*24 hours)
+  iam_key_rotation_days   = 30                                 # rotate key if older than 30 days
   sync_base_path          = "sys/sync/destinations"
   destination_name        = "${var.name}-${var.region}-${random_id.this.hex}"
   delete_sync_destination = alltrue([var.delete_all_secret_associations, var.delete_sync_destination])


### PR DESCRIPTION
Shorten key rotation duration to 30 days