### PR TITLE
feat!: typed vault_secrets_sync resources + one-command teardown (v1.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ example: *tfplan*
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Create and manage [Vault Enterprise Secret Sync](https://developer.hashicorp.com
 
 ## Note
 - This module currently only supports [AWS Secrets Manager destination](https://developer.hashicorp.com/vault/docs/sync/awssm). Other [secret sync destinations](https://developer.hashicorp.com/vault/docs/sync#destinations) will be supported in the future.
-- All the vault secret associations must be removed before the secret sync destination can be removed. Vault will return this error message if secret associations still exist: `store cannot be deleted because it is still managing secrets`.
+- The destination and associations are managed with the first-class `vault_secrets_sync_aws_destination` and `vault_secrets_sync_association` resources (Vault 1.16+ Enterprise). Removal is ordered by the resource graph — associations are destroyed before the destination — so no manual delete flags are needed.
 
 ## Usage
-Create Vault Secret Sync destination and secret association:
+Create the Vault Secret Sync destination and secret associations:
 ```terraform
 module "vault_secretsync" {
   source  = "SPHTech-Platform/secret-sync/vault"
-  version = "~> 0.1.0"
+  version = "~> 1.0"
 
   name = "vault-ss"
 
@@ -30,86 +30,9 @@ module "vault_secretsync" {
 }
 ```
 
-Remove some vault secrets from association by adding the attribute `unassociate_secrets`:
-```terraform
-module "vault_secretsync" {
-  source  = "SPHTech-Platform/secret-sync/vault"
-  version = "~> 0.1.0"
+**Unsync a secret:** remove it from `associate_secrets` (or drop a `secret_name` from the list) and apply — the corresponding association is destroyed, which unsyncs it. The destination and other associations are untouched.
 
-  name = "vault-ss"
-
-  # Removing secret in this section does not remove the secret association
-  associate_secrets = {
-    foo = {
-      mount       = "mount_foo"
-      secret_name = ["foo_secret"]
-    }
-  }
-
-  # Add the secret information here to remove the secret association
-  unassociate_secrets = {
-    hello = {
-      mount       = "mount_hello"
-      secret_name = [
-        "hello_secret_1",
-        "hello_secret_2",
-      ]
-    }
-  }
-}
-```
-
-Remove all vault secrets from association by adding the attribute `delete_all_secret_associations = true`:
-```terraform
-module "vault_secretsync" {
-  source  = "SPHTech-Platform/secret-sync/vault"
-  version = "~> 0.1.0"
-
-  name = "vault-ss"
-
-  associate_secrets = {
-    foo = {
-      mount       = "mount_foo"
-      secret_name = ["foo_secret"]
-    }
-    hello = {
-      mount       = "mount_hello"
-      secret_name = [
-        "hello_secret_1",
-        "hello_secret_2",
-      ]
-    }
-  }
-
-  delete_all_secret_associations = true
-}
-```
-
-Remove vault secret sync destination by adding `delete_sync_destination = true` (NOTE: all secret associations must be removed before this can be done i.e. `delete_all_secret_associations = true`):
-```terraform
-module "vault_secretsync" {
-  source  = "SPHTech-Platform/secret-sync/vault"
-  version = "~> 0.1.0"
-
-  name = "vault-ss"
-
-  associate_secrets = {
-    foo = {
-      mount       = "mount_foo"
-      secret_name = ["foo_secret"]
-    }
-    hello = {
-      mount       = "mount_hello"
-      secret_name = [
-        "hello_secret_1",
-        "hello_secret_2",
-      ]
-    }
-  }
-
-  delete_all_secret_associations = true
-  delete_sync_destination        = true
-```
+**Tear everything down:** run `terraform destroy`. Terraform destroys the associations first (each references the destination), then the destination, then the IAM user/key — no flags, no multi-step apply.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/data.tf
+++ b/data.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "vault_ent_secrets_manager_access" {
       "secretsmanager:UntagResource",
     ]
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:vault/*"
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:vault/*"
     ]
   }
 }

--- a/examples/.envrc.example
+++ b/examples/.envrc.example
@@ -1,0 +1,9 @@
+# Copy to .envrc (gitignored), fill in, then run `direnv allow`.
+# Prefer exporting VAULT_TOKEN in your shell over storing it in a file.
+
+export VAULT_ADDR="https://<cluster>.private.vault.<cluster-uuid>.aws.hashicorp.cloud:8200"
+export VAULT_NAMESPACE="admin"        # or a child namespace, e.g. admin/team/app
+export AWS_REGION="ap-southeast-1"
+
+# export VAULT_TOKEN="..."            # prefer an in-shell export over a file
+# AWS credentials via SSO / profile:  aws sso login --profile <profile>

--- a/examples/.envrc.example
+++ b/examples/.envrc.example
@@ -3,7 +3,7 @@
 
 export VAULT_ADDR="https://<cluster>.private.vault.<cluster-uuid>.aws.hashicorp.cloud:8200"
 export VAULT_NAMESPACE="admin"        # or a child namespace, e.g. admin/team/app
-export AWS_REGION="ap-southeast-1"
 
 # export VAULT_TOKEN="..."            # prefer an in-shell export over a file
 # AWS credentials via SSO / profile:  aws sso login --profile <profile>
+# Region is set in the example locals (var.region), not from the environment.

--- a/examples/.envrc.example
+++ b/examples/.envrc.example
@@ -6,4 +6,3 @@ export VAULT_NAMESPACE="admin"        # or a child namespace, e.g. admin/team/ap
 
 # export VAULT_TOKEN="..."            # prefer an in-shell export over a file
 # AWS credentials via SSO / profile:  aws sso login --profile <profile>
-# Region is set in the example locals (var.region), not from the environment.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,35 +1,35 @@
 # End-to-end example: sync a Vault KV v2 secret to AWS Secrets Manager.
 #
 # Self-contained — creates a throwaway KV v2 mount + secret, then syncs it.
-# Edit the locals below, then `terraform init && terraform apply`.
 #
-# Auth (supply via environment, never hard-coded):
-#   export VAULT_TOKEN=<token with write on sys/sync + the target namespace>
-#   AWS credentials via your usual mechanism (SSO / env / profile)
+# Provider config is read from the environment, so no cluster-specific or
+# sensitive values live in this file. Set them before running — via a gitignored
+# .envrc with direnv (see .envrc.example), or plain exports:
+#   export VAULT_ADDR=...        # cluster endpoint, reachable from where you run
+#   export VAULT_NAMESPACE=...   # e.g. admin, or a child namespace
+#   export VAULT_TOKEN=...       # token with sys/sync write in that namespace
+#   export AWS_REGION=ap-southeast-1
+#   AWS credentials via SSO / profile / env
 #
-# Teardown: terraform destroy. Associations are destroyed before the
-#   destination automatically (the association references the destination), so
-#   no delete flags are needed. Removing a secret from associate_secrets unsyncs
-#   just that one.
+# Run:      terraform init && terraform apply
+# Teardown: terraform destroy   (associations are removed before the destination
+#           automatically — no delete flags)
 
 data "aws_caller_identity" "current" {}
 
 locals {
-  region          = "ap-southeast-1"
-  vault_address   = "https://<cluster>.private.vault.<cluster-uuid>.aws.hashicorp.cloud:8200"
-  vault_namespace = "admin"
-  kv_mount        = "example-secret-sync"
-  secret_name     = "example"
+  region      = "ap-southeast-1"
+  kv_mount    = "example-secret-sync"
+  secret_name = "example"
 }
 
+# Credentials from the environment (AWS_PROFILE / AWS_ACCESS_KEY_ID / ...).
 provider "aws" {
   region = local.region
 }
 
-provider "vault" {
-  address   = local.vault_address
-  namespace = local.vault_namespace
-}
+# Address, namespace, and token from VAULT_ADDR / VAULT_NAMESPACE / VAULT_TOKEN.
+provider "vault" {}
 
 resource "vault_mount" "this" {
   path        = local.kv_mount

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -7,9 +7,10 @@
 #   export VAULT_TOKEN=<token with write on sys/sync + the target namespace>
 #   AWS credentials via your usual mechanism (SSO / env / profile)
 #
-# Teardown (associations must go before the destination):
-#   in the module block set delete_all_secret_associations = true, apply;
-#   then also set delete_sync_destination = true, apply; then terraform destroy.
+# Teardown: terraform destroy. Associations are destroyed before the
+#   destination automatically (the association references the destination), so
+#   no delete flags are needed. Removing a secret from associate_secrets unsyncs
+#   just that one.
 
 data "aws_caller_identity" "current" {}
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,19 +1,6 @@
-# End-to-end example: sync a Vault KV v2 secret to AWS Secrets Manager.
-#
-# Self-contained — creates a throwaway KV v2 mount + secret, then syncs it.
-#
-# Provider config is read from the environment, so no cluster-specific or
-# sensitive values live in this file. Set them before running — via a gitignored
-# .envrc with direnv (see .envrc.example), or plain exports:
-#   export VAULT_ADDR=...        # cluster endpoint, reachable from where you run
-#   export VAULT_NAMESPACE=...   # e.g. admin, or a child namespace
-#   export VAULT_TOKEN=...       # token with sys/sync write in that namespace
-#   export AWS_REGION=ap-southeast-1
-#   AWS credentials via SSO / profile / env
-#
-# Run:      terraform init && terraform apply
-# Teardown: terraform destroy   (associations are removed before the destination
-#           automatically — no delete flags)
+# Syncs a throwaway KV v2 secret to AWS Secrets Manager. Provider config comes
+# from the environment (VAULT_ADDR / VAULT_NAMESPACE / VAULT_TOKEN, AWS creds) —
+# see .envrc.example. Teardown: terraform destroy.
 
 data "aws_caller_identity" "current" {}
 
@@ -23,12 +10,10 @@ locals {
   secret_name = "example"
 }
 
-# Credentials from the environment (AWS_PROFILE / AWS_ACCESS_KEY_ID / ...).
 provider "aws" {
   region = local.region
 }
 
-# Address, namespace, and token from VAULT_ADDR / VAULT_NAMESPACE / VAULT_TOKEN.
 provider "vault" {}
 
 resource "vault_mount" "this" {

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 3.23.0"
+      version = ">= 3.25.0"
     }
   }
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.0"
     }
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 3.25.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 6.0.0"
     }
     vault = {
       source  = "hashicorp/vault"

--- a/locals.tf
+++ b/locals.tf
@@ -1,23 +1,11 @@
 locals {
   # checks for keys older than 30 days
-  age_in_days             = timeadd(plantimestamp(), "-720h") # 30 days (30*24 hours)
-  iam_key_rotation_days   = 30                                # rotate key if older than 30 days
-  sync_base_path          = "sys/sync/destinations"
-  destination_name        = "${var.name}-${var.region}-${random_id.this.hex}"
-  delete_sync_destination = alltrue([var.delete_all_secret_associations, var.delete_sync_destination])
+  age_in_days           = timeadd(plantimestamp(), "-720h") # 30 days (30*24 hours)
+  iam_key_rotation_days = 30                                # rotate key if older than 30 days
+  destination_name      = "${var.name}-${var.region}-${random_id.this.hex}"
 
   associate_secrets = flatten([
     for app_name, secret in var.associate_secrets : [
-      for secret_name in secret.secret_name : {
-        app_name    = app_name
-        mount       = secret.mount
-        secret_name = secret_name
-      }
-    ]
-  ])
-
-  unassociate_secrets = flatten([
-    for app_name, secret in var.unassociate_secrets : [
       for secret_name in secret.secret_name : {
         app_name    = app_name
         mount       = secret.mount

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,8 @@ resource "vault_secrets_sync_aws_destination" "this" {
 # References the destination, so destroy removes associations first — teardown
 # needs no delete flags.
 resource "vault_secrets_sync_association" "this" {
-  for_each = { for secret in local.associate_secrets : "${secret.app_name}-${secret.secret_name}" => secret }
+  # jsonencode key avoids collisions when app_name/mount/secret_name contain "-".
+  for_each = { for secret in local.associate_secrets : jsonencode([secret.app_name, secret.mount, secret.secret_name]) => secret }
 
   name        = vault_secrets_sync_aws_destination.this.name
   type        = vault_secrets_sync_aws_destination.this.type

--- a/main.tf
+++ b/main.tf
@@ -4,11 +4,8 @@
 #                                     #
 #######################################
 
-# Wait for the freshly-created IAM access key to propagate in AWS before Vault
-# uses it. New keys are eventually-consistent; without this, Vault initializes
-# the aws-sm store with a key AWS does not yet recognize and returns
-# `InvalidClientTokenId` (AWS STS 403 -> Vault 500). Re-created on key rotation
-# (trigger below) so the update path waits too.
+# New IAM keys are eventually-consistent; using one before it propagates makes
+# store init fail with InvalidClientTokenId. Re-triggered on key rotation.
 resource "time_sleep" "wait_for_key_propagation" {
   create_duration = "30s"
 
@@ -17,20 +14,17 @@ resource "time_sleep" "wait_for_key_propagation" {
   }
 }
 
-# Vault -> AWS Secrets Manager destination (one per region).
 resource "vault_secrets_sync_aws_destination" "this" {
   name              = local.destination_name
   access_key_id     = aws_iam_access_key.vault_secretsync.id
   secret_access_key = aws_iam_access_key.vault_secretsync.secret
   region            = var.region
 
-  # Do not hand the key to Vault until it has propagated in AWS.
   depends_on = [time_sleep.wait_for_key_propagation]
 }
 
-# Vault secret -> AWS SM association. Removing an entry from associate_secrets
-# (or `terraform destroy`) unsyncs it; the association is destroyed before the
-# destination because it references the destination, so teardown needs no flags.
+# References the destination, so destroy removes associations first — teardown
+# needs no delete flags.
 resource "vault_secrets_sync_association" "this" {
   for_each = { for secret in local.associate_secrets : "${secret.app_name}-${secret.secret_name}" => secret }
 

--- a/main.tf
+++ b/main.tf
@@ -17,83 +17,25 @@ resource "time_sleep" "wait_for_key_propagation" {
   }
 }
 
-# Create Vault -> AWS SM destination
-# Only need to create one destination per AWS region
-resource "vault_generic_endpoint" "create_destination_sync" {
-  count = local.delete_sync_destination ? 0 : 1
-
-  path = "${local.sync_base_path}/aws-sm/${local.destination_name}"
-
-  data_json = jsonencode({
-    access_key_id     = aws_iam_access_key.vault_secretsync.id
-    secret_access_key = aws_iam_access_key.vault_secretsync.secret
-    region            = var.region
-  })
-
-  disable_delete       = false
-  disable_read         = true
-  ignore_absent_fields = true
+# Vault -> AWS Secrets Manager destination (one per region).
+resource "vault_secrets_sync_aws_destination" "this" {
+  name              = local.destination_name
+  access_key_id     = aws_iam_access_key.vault_secretsync.id
+  secret_access_key = aws_iam_access_key.vault_secretsync.secret
+  region            = var.region
 
   # Do not hand the key to Vault until it has propagated in AWS.
   depends_on = [time_sleep.wait_for_key_propagation]
 }
 
-resource "time_sleep" "wait_for_destination_sync" {
-  create_duration = "10s"
-
-  depends_on = [
-    vault_generic_endpoint.create_destination_sync,
-  ]
-}
-
-# Create Vault Secret -> AWS SM association
-resource "vault_generic_endpoint" "create_association_sync" {
+# Vault secret -> AWS SM association. Removing an entry from associate_secrets
+# (or `terraform destroy`) unsyncs it; the association is destroyed before the
+# destination because it references the destination, so teardown needs no flags.
+resource "vault_secrets_sync_association" "this" {
   for_each = { for secret in local.associate_secrets : "${secret.app_name}-${secret.secret_name}" => secret }
 
-  path = "${local.sync_base_path}/aws-sm/${local.destination_name}/associations/set"
-
-  data_json = jsonencode({
-    mount       = each.value.mount
-    secret_name = each.value.secret_name
-  })
-
-  disable_delete       = true
-  disable_read         = true
-  ignore_absent_fields = true
-
-  depends_on = [
-    time_sleep.wait_for_destination_sync,
-  ]
-}
-
-# Remove Some Vault Secret -> AWS SM association
-resource "vault_generic_endpoint" "remove_some_association_sync" {
-  for_each = { for secret in local.unassociate_secrets : "${secret.app_name}-${secret.secret_name}" => secret }
-
-  path = "${local.sync_base_path}/aws-sm/${local.destination_name}/associations/remove"
-
-  data_json = jsonencode({
-    mount       = each.value.mount
-    secret_name = each.value.secret_name
-  })
-
-  disable_delete       = true
-  disable_read         = true
-  ignore_absent_fields = true
-}
-
-# Remove ALL Vault Secret -> AWS SM destination
-resource "vault_generic_endpoint" "remove_all_association_sync" {
-  for_each = var.delete_all_secret_associations ? { for secret in local.associate_secrets : "${secret.app_name}-${secret.secret_name}" => secret } : {}
-
-  path = "${local.sync_base_path}/aws-sm/${local.destination_name}/associations/remove"
-
-  data_json = jsonencode({
-    mount       = each.value.mount
-    secret_name = each.value.secret_name
-  })
-
-  disable_delete       = true
-  disable_read         = true
-  ignore_absent_fields = true
+  name        = vault_secrets_sync_aws_destination.this.name
+  type        = vault_secrets_sync_aws_destination.this.type
+  mount       = each.value.mount
+  secret_name = each.value.secret_name
 }

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,6 @@ resource "vault_secrets_sync_aws_destination" "this" {
 # References the destination, so destroy removes associations first — teardown
 # needs no delete flags.
 resource "vault_secrets_sync_association" "this" {
-  # jsonencode key avoids collisions when app_name/mount/secret_name contain "-".
   for_each = { for secret in local.associate_secrets : jsonencode([secret.app_name, secret.mount, secret.secret_name]) => secret }
 
   name        = vault_secrets_sync_aws_destination.this.name

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,10 @@ resource "vault_secrets_sync_aws_destination" "this" {
   secret_access_key = aws_iam_access_key.vault_secretsync.secret
   region            = var.region
 
+  custom_tags          = var.custom_tags
+  secret_name_template = var.secret_name_template
+  granularity          = var.granularity
+
   depends_on = [time_sleep.wait_for_key_propagation]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "destination_name" {
+  description = "Name of the AWS Secrets Manager sync destination."
+  value       = vault_secrets_sync_aws_destination.this.name
+}
+
+output "sync_status" {
+  description = "Per-association sync status, keyed by <app>-<secret_name>."
+  value       = { for k, assoc in vault_secrets_sync_association.this : k => assoc.sync_status }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,8 +2,3 @@ output "destination_name" {
   description = "Name of the AWS Secrets Manager sync destination."
   value       = vault_secrets_sync_aws_destination.this.name
 }
-
-output "sync_status" {
-  description = "Per-association sync status, keyed by <app>-<secret_name>."
-  value       = { for k, assoc in vault_secrets_sync_association.this : k => assoc.sync_status }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,39 +1,39 @@
 variable "name" {
-  type        = string
   description = "Prefix name for the destination"
+  type        = string
 }
 
 variable "region" {
+  description = "AWS region"
   type        = string
   default     = "ap-southeast-1"
-  description = "AWS region"
 }
 
 variable "associate_secrets" {
+  description = "Map of vault kv secrets to sync to the AWS Secrets Manager destination. Remove an entry (or run terraform destroy) to unsync it."
   type = map(
     object({
       mount       = string
       secret_name = list(string)
     })
   )
-  default     = {}
-  description = "Map of vault kv secrets to sync to the AWS Secrets Manager destination. Remove an entry (or run terraform destroy) to unsync it."
+  default = {}
 }
 
 variable "custom_tags" {
+  description = "Custom tags to set on the secrets managed at the destination."
   type        = map(string)
   default     = {}
-  description = "Custom tags to set on the secrets managed at the destination."
 }
 
 variable "secret_name_template" {
+  description = "Template for external secret names. Leave null to use Vault's default (includes the mount accessor)."
   type        = string
   default     = null
-  description = "Template for external secret names. Leave null to use Vault's default (includes the mount accessor)."
 }
 
 variable "granularity" {
+  description = "Level of information synced as a distinct resource: secret-path or secret-key. Null uses Vault's default."
   type        = string
   default     = null
-  description = "Level of information synced as a distinct resource: secret-path or secret-key. Null uses Vault's default."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,3 @@
-variable "delete_sync_destination" {
-  type        = bool
-  default     = false
-  description = "Delete the sync destination. Secret associations must be removed beforehand."
-}
-
-variable "delete_all_secret_associations" {
-  type        = bool
-  default     = false
-  description = "Delete the secret associations"
-}
-
 variable "name" {
   type        = string
   description = "Prefix name for the destination"
@@ -29,16 +17,5 @@ variable "associate_secrets" {
     })
   )
   default     = {}
-  description = "Map of vault kv to create secret sync association"
-}
-
-variable "unassociate_secrets" {
-  type = map(
-    object({
-      mount       = string
-      secret_name = list(string)
-    })
-  )
-  default     = {}
-  description = "Map of vault kv to remove secret sync association"
+  description = "Map of vault kv secrets to sync to the AWS Secrets Manager destination. Remove an entry (or run terraform destroy) to unsync it."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,21 @@ variable "associate_secrets" {
   default     = {}
   description = "Map of vault kv secrets to sync to the AWS Secrets Manager destination. Remove an entry (or run terraform destroy) to unsync it."
 }
+
+variable "custom_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Custom tags to set on the secrets managed at the destination."
+}
+
+variable "secret_name_template" {
+  type        = string
+  default     = null
+  description = "Template for external secret names. Leave null to use Vault's default (includes the mount accessor)."
+}
+
+variable "granularity" {
+  type        = string
+  default     = null
+  description = "Level of information synced as a distinct resource: secret-path or secret-key. Null uses Vault's default."
+}

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 3.23.0"
+      version = ">= 3.25.0" # vault_secrets_sync_* typed resources (Vault 1.16+ Enterprise)
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 3.25.0"
+      version = ">= 4.2.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 6.0.0"
     }
     vault = {
       source  = "hashicorp/vault"

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 3.25.0" # vault_secrets_sync_* typed resources (Vault 1.16+ Enterprise)
+      version = ">= 3.25.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary

Manage the AWS Secrets Manager destination and secret associations with the first-class **`vault_secrets_sync_aws_destination`** and **`vault_secrets_sync_association`** resources, replacing the raw `vault_generic_endpoint` API passthrough.

Motivated by teardown: `vault_generic_endpoint` has no `associations/remove` delete semantics, so the previous module faked ordering with `disable_delete = true` + `delete_all_secret_associations` / `delete_sync_destination` flags, forcing a **2-apply + destroy** teardown. The typed resources model proper CRUD, and the association references the destination — so Terraform destroys associations before the destination automatically.

## What changes for callers

- **Teardown is now one command:** `terraform destroy`. No flags, no multi-step apply.
- **Unsync a secret:** remove it from `associate_secrets` and apply.
- **Removed inputs:** `delete_all_secret_associations`, `delete_sync_destination`, `unassociate_secrets`.
- **New optional inputs:** `custom_tags`, `secret_name_template`, `granularity` (null/empty defaults preserve current behavior — `secret_name_template` unset keeps Vault's default accessor-based naming, so existing AWS SM secret names are unchanged).
- **New outputs:** `destination_name`.
- The IAM key propagation-wait fix from v0.2.1 is retained on the destination.

## Provider requirements (breaking)

- **vault `>= 4.2.0`** — typed secrets-sync resources + the `granularity` arg (introduced in provider 4.2.0; Vault 1.16+ Enterprise).
- **aws `>= 6.0.0`** — bumped from `>= 4.67.0`; also switches `data.aws_region.current.name` to `.region` (the old attribute is deprecated in aws 6.x). `terraform-aws-modules/iam ~> 5.32` resolves cleanly against aws 6.x.

## Breaking change / upgrade note

Resource **types** change (`vault_generic_endpoint` → `vault_secrets_sync_*`), so `moved {}` blocks cannot bridge the state. Upgrading from 0.x **recreates** the destination + associations, causing a brief re-sync. Secret **names** in AWS SM are unchanged (same default template), so no orphaned secrets. Plan the upgrade in a maintenance window, or use `terraform state` surgery to import into the new addresses.

Releasing as **v1.0.0**.

## Testing

- `terraform fmt` + `terraform validate` pass against vault v5.10.1 / aws v6.54.0.
- **End-to-end validated** on a throwaway namespace (`admin/engr/platform_eng`) via `examples/`:
  - `tofu apply` — destination + association create first-try (propagation wait holds; no `InvalidClientTokenId`).
  - Secret confirmed present in AWS Secrets Manager.
  - `tofu destroy` — single command, associations removed before the destination, no `store cannot be deleted…` error.
- Copilot review addressed: collision-resistant `for_each` key; removed a dead `AWS_REGION` example export. (Upper-bounding the provider constraint was intentionally not applied — HashiCorp advises against upper bounds in reusable modules.)
